### PR TITLE
implemented size calculations.

### DIFF
--- a/src/main/java/de/waldheinz/fs/fat/FatFileSystem.java
+++ b/src/main/java/de/waldheinz/fs/fat/FatFileSystem.java
@@ -237,50 +237,42 @@ public final class FatFileSystem extends AbstractFileSystem {
     }
 
     /**
-     * <p>
-     * {@inheritDoc}
-     * </p><p>
-     * This method is currently not implemented for {@code FatFileSystem} and
-     * always returns -1.
-     * </p>
-     * 
-     * @return always -1
+     * The free space of this file system.
+     *
+     * @return if -1 this feature is unsupported
      */
     @Override
     public long getFreeSpace() {
-        // TODO implement me
-        return -1;
+        checkClosed();
+
+        return fat.getFreeClusterCount() * bs.getBytesPerCluster();
     }
 
     /**
-     * <p>
-     * {@inheritDoc}
-     * </p><p>
-     * This method is currently not implemented for {@code FatFileSystem} and
-     * always returns -1.
-     * </p>
+     * The total size of this file system.
      *
-     * @return always -1
+     * @return if -1 this feature is unsupported
      */
     @Override
     public long getTotalSpace() {
-        // TODO implement me
+        checkClosed();
+
+        if (fatType == FatType.FAT32) {
+            return bs.getNrTotalSectors() * bs.getBytesPerSector();
+        }
+
         return -1;
     }
 
     /**
-     * <p>
-     * {@inheritDoc}
-     * </p><p>
-     * This method is currently not implemented for {@code FatFileSystem} and
-     * always returns -1.
-     * </p>
+     * The usable space of this file system.
      *
-     * @return always -1
+     * @return if -1 this feature is unsupported
      */
     @Override
     public long getUsableSpace() {
-        // TODO implement me
-        return -1;
+        checkClosed();
+
+        return bs.getDataClusterCount() * bs.getBytesPerCluster();
     }
 }

--- a/src/test/java/de/waldheinz/fs/fat/FileSystemSizeTest.java
+++ b/src/test/java/de/waldheinz/fs/fat/FileSystemSizeTest.java
@@ -1,0 +1,55 @@
+package de.waldheinz.fs.fat;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.InputStream;
+
+import de.waldheinz.fs.util.RamDisk;
+
+/**
+ * @author Jan Seeger <jan@alphadev.net>
+ */
+public class FileSystemSizeTest {
+    @Test
+    public void testFat32Size() throws Exception {
+        System.out.println("fat32Size");
+
+        final InputStream is = getClass().getResourceAsStream(
+                "fat32-test.img.gz");
+
+        final RamDisk rd = RamDisk.readGzipped(is);
+        final FatFileSystem fatFs = new FatFileSystem(rd, false);
+        Assert.assertEquals(39366 * 1024, fatFs.getFreeSpace());
+        Assert.assertEquals(39368 * 1024, fatFs.getUsableSpace());
+        Assert.assertEquals(40000 * 1024, fatFs.getTotalSpace());
+    }
+
+    @Test
+    public void testFat12Size() throws Exception {
+        System.out.println("fat12Size");
+
+        final InputStream is = getClass().getResourceAsStream(
+                "fat12-test.img.gz");
+
+        final RamDisk rd = RamDisk.readGzipped(is);
+        final FatFileSystem fatFs = new FatFileSystem(rd, false);
+        Assert.assertEquals(998 * 1024, fatFs.getFreeSpace());
+        Assert.assertEquals(1004 * 1024, fatFs.getUsableSpace());
+        Assert.assertEquals(-1, fatFs.getTotalSpace());
+    }
+
+    @Test
+    public void testFat16Size() throws Exception {
+        System.out.println("fat16Size");
+
+        final InputStream is = getClass().getResourceAsStream(
+                "fat16-test.img.gz");
+
+        final RamDisk rd = RamDisk.readGzipped(is);
+        final FatFileSystem fatFs = new FatFileSystem(rd, false);
+        Assert.assertEquals(9956 * 1024, fatFs.getFreeSpace());
+        Assert.assertEquals(9962 * 1024, fatFs.getUsableSpace());
+        Assert.assertEquals(-1, fatFs.getTotalSpace());
+    }
+}


### PR DESCRIPTION
still not sure if total/free/used would be better than this.

Unit test sizes have been checked aganst Unix `df`:

```
/dev/loop0          1004         6       998   1% /media/jan/8716-FC70
/dev/loop0          9962         6      9956   1% /media/jan/B384-1B23
/dev/loop0         39368         2     39366   1% /media/jan/testdisk
```
